### PR TITLE
Don't promisfy meraki controller functions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   "dependencies": {
     "@lifeomic/attempt": "^3.0.0",
     "meraki": "^1.5.0",
-    "node-fetch": "^2.6.0",
-    "promisfy": "^1.2.0"
+    "node-fetch": "^2.6.0"
   },
   "devDependencies": {
     "@jupiterone/integration-sdk-core": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-cisco-meraki",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A graph conversion tool for https://meraki.cisco.com",
   "license": "MPL-2.0",
   "files": [

--- a/src/collector/ServicesClient.ts
+++ b/src/collector/ServicesClient.ts
@@ -29,7 +29,7 @@ export class ServicesClient {
    */
   async getOrganizations(): Promise<MerakiOrganization[]> {
     const res: object[] = await meraki.OrganizationsController.getOrganizations();
-    return res[0] as MerakiOrganization[];
+    return res as MerakiOrganization[];
   }
 
   /**
@@ -39,7 +39,7 @@ export class ServicesClient {
     const res: object[] = await meraki.AdminsController.getOrganizationAdmins(
       organizationId,
     );
-    return res[0] as MerakiAdminUser[];
+    return res as MerakiAdminUser[];
   }
 
   /**
@@ -49,7 +49,7 @@ export class ServicesClient {
     const res: object[] = await meraki.SAMLRolesController.getOrganizationSamlRoles(
       organizationId,
     );
-    return res[0] as MerakiSamlRole[];
+    return res as MerakiSamlRole[];
   }
 
   /**
@@ -61,7 +61,7 @@ export class ServicesClient {
         organizationId,
       },
     );
-    return res[0] as MerakiNetwork[];
+    return res as MerakiNetwork[];
   }
 
   /**
@@ -71,7 +71,7 @@ export class ServicesClient {
     const res: object[] = await meraki.VlansController.getNetwork_vlans(
       networkId,
     );
-    return res[0] as MerakiVlan[];
+    return res as MerakiVlan[];
   }
 
   /**
@@ -81,7 +81,7 @@ export class ServicesClient {
     const res: object[] = await meraki.DevicesController.getNetworkDevices(
       networkId,
     );
-    return res[0] as MerakiDevice[];
+    return res as MerakiDevice[];
   }
 
   /**
@@ -91,7 +91,7 @@ export class ServicesClient {
     const res: object[] = await meraki.ClientsController.getNetworkClients({
       networkId,
     });
-    return res[0] as MerakiClient[];
+    return res as MerakiClient[];
   }
 
   /**
@@ -101,6 +101,6 @@ export class ServicesClient {
     const res: object[] = await meraki.SsidsController.getNetwork_ssids(
       networkId,
     );
-    return res[0] as MerakiSSID[];
+    return res as MerakiSSID[];
   }
 }

--- a/src/collector/ServicesClient.ts
+++ b/src/collector/ServicesClient.ts
@@ -1,5 +1,4 @@
 import meraki = require('meraki');
-import { promisfy } from 'promisfy';
 import {
   MerakiOrganization,
   MerakiNetwork,
@@ -29,10 +28,7 @@ export class ServicesClient {
    * Get Organizations
    */
   async getOrganizations(): Promise<MerakiOrganization[]> {
-    const getOrganizations = promisfy(
-      meraki.OrganizationsController.getOrganizations,
-    );
-    const res: object[] = await getOrganizations();
+    const res: object[] = await meraki.OrganizationsController.getOrganizations();
     return res[0] as MerakiOrganization[];
   }
 
@@ -40,10 +36,9 @@ export class ServicesClient {
    * Get Admin Users of an Organization
    */
   async getAdmins(organizationId: string): Promise<MerakiAdminUser[]> {
-    const getOrganizationAdmins = promisfy(
-      meraki.AdminsController.getOrganizationAdmins,
+    const res: object[] = await meraki.AdminsController.getOrganizationAdmins(
+      organizationId,
     );
-    const res: object[] = await getOrganizationAdmins(organizationId);
     return res[0] as MerakiAdminUser[];
   }
 
@@ -51,10 +46,9 @@ export class ServicesClient {
    * Get SAML Roles of an Organization
    */
   async getSamlRoles(organizationId: string): Promise<MerakiSamlRole[]> {
-    const getOrganizationSamlRoles = promisfy(
-      meraki.SAMLRolesController.getOrganizationSamlRoles,
+    const res: object[] = await meraki.SAMLRolesController.getOrganizationSamlRoles(
+      organizationId,
     );
-    const res: object[] = await getOrganizationSamlRoles(organizationId);
     return res[0] as MerakiSamlRole[];
   }
 
@@ -62,12 +56,11 @@ export class ServicesClient {
    * Get Networks of an Organization
    */
   async getNetworks(organizationId: string): Promise<MerakiNetwork[]> {
-    const getOrganizationNetworks = promisfy(
-      meraki.NetworksController.getOrganizationNetworks,
+    const res: object[] = await meraki.NetworksController.getOrganizationNetworks(
+      {
+        organizationId,
+      },
     );
-    const res: object[] = await getOrganizationNetworks({
-      organizationId,
-    });
     return res[0] as MerakiNetwork[];
   }
 
@@ -75,8 +68,9 @@ export class ServicesClient {
    * Get VLANs in a Network
    */
   async getVlans(networkId: string): Promise<MerakiVlan[]> {
-    const getNetworkVlans = promisfy(meraki.VlansController.getNetwork_vlans);
-    const res: object[] = await getNetworkVlans(networkId);
+    const res: object[] = await meraki.VlansController.getNetwork_vlans(
+      networkId,
+    );
     return res[0] as MerakiVlan[];
   }
 
@@ -84,10 +78,9 @@ export class ServicesClient {
    * Get Devices in a Network
    */
   async getDevices(networkId: string): Promise<MerakiDevice[]> {
-    const getNetworkDevices = promisfy(
-      meraki.DevicesController.getNetworkDevices,
+    const res: object[] = await meraki.DevicesController.getNetworkDevices(
+      networkId,
     );
-    const res: object[] = await getNetworkDevices(networkId);
     return res[0] as MerakiDevice[];
   }
 
@@ -95,10 +88,9 @@ export class ServicesClient {
    * Get Clients in a Network
    */
   async getClients(networkId: string): Promise<MerakiClient[]> {
-    const getNetworkClients = promisfy(
-      meraki.ClientsController.getNetworkClients,
-    );
-    const res: object[] = await getNetworkClients({ networkId });
+    const res: object[] = await meraki.ClientsController.getNetworkClients({
+      networkId,
+    });
     return res[0] as MerakiClient[];
   }
 
@@ -106,8 +98,9 @@ export class ServicesClient {
    * Get SSIDs of a Wireless Network
    */
   async getSSIDs(networkId: string): Promise<MerakiSSID[]> {
-    const getNetworkSSIDs = promisfy(meraki.SsidsController.getNetwork_ssids);
-    const res: object[] = await getNetworkSSIDs(networkId);
+    const res: object[] = await meraki.SsidsController.getNetwork_ssids(
+      networkId,
+    );
     return res[0] as MerakiSSID[];
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4854,10 +4854,6 @@ promise-polyfill@^8.1.3:
   version "8.1.3"
   resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
 
-promisfy@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/promisfy/-/promisfy-1.2.0.tgz#d34cfec196bddd6a2cfa0bf64eaca53dbc9250a8"
-
 prompts@^2.0.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.3.2.tgz#480572d89ecf39566d2bd3fe2c9fccb7c4c0b068"


### PR DESCRIPTION
So the controller functions already return a promise. Here's pretty much what is returned at the end of every function:
```
        return new Promise((_fulfill, _reject) => {
            _request(_options, (_error, _response, _context) => {
                let errorResponse;
                if (_error) {
                    errorResponse = _baseController.validateResponse(_context);
                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
                    _reject(errorResponse.error);
                } else if (_response.statusCode >= 200 && _response.statusCode <= 206) {
                    const parsed = JSON.parse(_response.body);
                    _callback(null, parsed, _context);
                    _fulfill(parsed);
                } else {
                    errorResponse = _baseController.validateResponse(_context);
                    _callback(errorResponse.error, errorResponse.response, errorResponse.context);
                    _reject(errorResponse.error);
                }
            });
        });
```

The unhandled rejection is happening because of the above `_reject` calls. The `promisfy` module assumes that the input function is just a regular callback function and doesn't try to handle any promise rejections (see [here](https://github.com/DanteLee/promisfy/blob/master/index.js#L24)).

@erkangz could you give this a quick run to confirm that collection works as expected locally?