### PR TITLE
Add _key to Internet entity to avoid creating duplicate

### DIFF
--- a/src/converter/entities.ts
+++ b/src/converter/entities.ts
@@ -194,6 +194,7 @@ export const convertDevice = (
 export const INTERNET_ENTITY = {
   _class: TargetEntities.INTERNET._class,
   _type: TargetEntities.INTERNET._type,
+  _key: 'global:internet',
   displayName: 'Internet',
   CIDR: '0.0.0.0/0',
   CIDRv6: '::/0',

--- a/src/steps/fetch-resources/index.ts
+++ b/src/steps/fetch-resources/index.ts
@@ -113,7 +113,7 @@ const step: IntegrationStep<IntegrationConfig> = {
                 _mapping: {
                   relationshipDirection: RelationshipDirection.FORWARD,
                   sourceEntityKey: device._key,
-                  targetFilterKeys: [['_type', 'CIDR']],
+                  targetFilterKeys: [['_key', 'CIDR']],
                   targetEntity: INTERNET_ENTITY,
                 },
               }),


### PR DESCRIPTION
In j1dev, we have two Internet entities. The first has the correct key (`global:internet`) and the second has a mapper-generated key from type and CIDR (`0.0.0.0/0:internet`). I believe the second Internet was created due to this integration, since there are multiple Cisco Meraki relationships to that Internet but none to the first, correct Internet.

I am not sure why this mapped relationship didn't find the existing correct Internet, since its type and CIDR target filter should have matched. Regardless, using key is safer, since the persister should perform upserts by key. I am also going to open a PR to the AWS integration to use key when we know that the target of a mapped relationship is the Internet.