### PR TITLE
[INT-2602] Adding VLANs enabled check. Prettier formatting and adding format:check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: 
+on:
   pull_request:
   push:
     branches:
@@ -87,6 +87,7 @@ jobs:
           tag_name: ${{ steps.changelog_reader.outputs.version }}
           release_name: Release ${{ steps.changelog_reader.outputs.version }}
           body: ${{ steps.changelog_reader.outputs.changes }}
-          prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
+          prerelease:
+            ${{ steps.changelog_reader.outputs.status == 'prereleased' }}
           draft: ${{ steps.changelog_reader.outputs.status == 'unreleased' }}
         continue-on-error: true

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,5 +1,5 @@
 name: gitleaks
-on: 
+on:
   pull_request:
   push:
     branches:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist
 coverage/
 .j1-integration
+.gitleaks.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `getVlans` method will now check if VLANs are enabled for the network before
+  trying to get them. This fixes an error where if VLANs are not enabled for a
+  network, calling `getNetwork_vlans` will result in an error like
+  `{error: "VLANS are not enabled for this network"}`
+
 ## 2.2.1 - 2021-10-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "graph:spec": "j1-integration visualize-types --project-path docs/spec --output-file ./.j1-integration/types-graph/index.spec.html",
     "lint": "eslint . --cache --fix --ext .ts,.tsx",
     "format": "prettier --write '**/*.{ts,js,json,css,md,yml}'",
+    "format:check": "prettier --check '**/*.{ts,js,json,css,md,yml}'",
     "type-check": "tsc",
     "test": "jest",
     "test:env": "LOAD_ENV=1 yarn test",
     "test:ci": "yarn lint && yarn type-check && yarn test",
     "build": "tsc -p tsconfig.dist.json --declaration && cp README.md dist/README.md",
-    "prepush": "yarn lint && yarn type-check && jest --changedSince main"
+    "prepush": "yarn format:check && yarn lint && yarn type-check && jest --changedSince main"
   },
   "peerDependencies": {
     "@jupiterone/integration-sdk-core": "^7.0.0"

--- a/src/collector/ServicesClient.ts
+++ b/src/collector/ServicesClient.ts
@@ -66,6 +66,18 @@ export class ServicesClient {
    * Get VLANs in a Network
    */
   async getVlans(networkId: string): Promise<MerakiVlan[]> {
+    const enabledResponse = await meraki.VlansController.getNetwork_vlans_EnabledState(
+      networkId,
+    );
+
+    // some networks may not have VLANs enabled.
+    // https://community.meraki.com/t5/Security-SD-WAN/MX-device-ports/m-p/102185
+    // https://community.cisco.com/t5/other-cloud-subjects/meraki-unable-to-get-vlan-info/td-p/4089912
+    // if Vlans aren't enabled we shouldn't try to get them
+    if (enabledResponse?.enabled === false) {
+      return [] as MerakiVlan[];
+    }
+
     const res = await meraki.VlansController.getNetwork_vlans(networkId);
     return res as MerakiVlan[];
   }


### PR DESCRIPTION
# Description

This PR adds a new check in the `serviceClient.getVlans` method. The check verifies that VLANs are enabled for the network before trying to retrieve them. This is to try to prevent the `{"errors":["VLANs are not enabled for this network"]}"}` error received.

## Summary

The main change is in `src/collector/ServiceClient.ts`. Here we add a new API call to `/networks/{networkId}/vlansEnabledState`. If `enabled` is set to `false`, we do not try to get the network's VLANs.