### PR TITLE
INT-4272 Add pagination

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: gitleaks-action
-        uses: zricethezav/gitleaks-action@master
+        uses: zricethezav/gitleaks-action@1.6.0

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: gitleaks-action
-        uses: zricethezav/gitleaks-action@1.6.0
+        uses: gitleaks/gitleaks-action@v1.6.0

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -110,7 +110,6 @@ The following mapped relationships are created:
 | --------------------- | --------------------- | --------------------- | --------- |
 | `meraki_device`       | **CONNECTS**          | `*internet*`          | FORWARD   |
 | `meraki_network`      | **HAS**               | `*host*`              | FORWARD   |
-| `meraki_vlan`         | **HAS**               | `*host*`              | FORWARD   |
 
 <!--
 ********************************************************************************

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -110,6 +110,7 @@ The following mapped relationships are created:
 | --------------------- | --------------------- | --------------------- | --------- |
 | `meraki_device`       | **CONNECTS**          | `*internet*`          | FORWARD   |
 | `meraki_network`      | **HAS**               | `*host*`              | FORWARD   |
+| `meraki_vlan`         | **HAS**               | `*host*`              | FORWARD   |
 
 <!--
 ********************************************************************************

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@jupiterone/integration-sdk-core": "^8.17.0",
     "@jupiterone/integration-sdk-dev-tools": "^8.17.0",
-    "@jupiterone/integration-sdk-testing": "^8.17.0"
+    "@jupiterone/integration-sdk-testing": "^8.17.0",
+    "@types/parse-link-header": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "graph": "j1-integration visualize",
     "graph:types": "j1-integration visualize-types",
     "graph:spec": "j1-integration visualize-types --project-path docs/spec --output-file ./.j1-integration/types-graph/index.spec.html",
+    "graph:dependencies": "j1-integration visualize-dependencies",
     "lint": "eslint . --cache --fix --ext .ts,.tsx",
     "format": "prettier --write '**/*.{ts,js,json,css,md,yml}'",
     "format:check": "prettier --check '**/*.{ts,js,json,css,md,yml}'",
@@ -27,14 +28,15 @@
     "prepush": "yarn format:check && yarn lint && yarn type-check && jest --changedSince main"
   },
   "peerDependencies": {
-    "@jupiterone/integration-sdk-core": "^7.0.0"
+    "@jupiterone/integration-sdk-core": "^8.17.0"
   },
   "dependencies": {
-    "gaxios": "^5.0.0"
+    "gaxios": "^5.0.0",
+    "parse-link-header": "^2.0.0"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-core": "^8.13.11",
-    "@jupiterone/integration-sdk-dev-tools": "^8.13.11",
-    "@jupiterone/integration-sdk-testing": "^8.13.11"
+    "@jupiterone/integration-sdk-core": "^8.17.0",
+    "@jupiterone/integration-sdk-dev-tools": "^8.17.0",
+    "@jupiterone/integration-sdk-testing": "^8.17.0"
   }
 }

--- a/src/collector/ServicesClient.ts
+++ b/src/collector/ServicesClient.ts
@@ -179,6 +179,13 @@ export class ServicesClient {
     await this.iterateAll(url, iteratee);
   }
 
+  /**
+   * iterateClients iterates all clients in a network
+   * @url https://developer.cisco.com/meraki/api-v1/#!get-network-clients
+   * @paginated true
+   * @param networkId the network id
+   * @param iteratee the iteratee callback function
+   */
   async iterateClients(
     networkId: string,
     iteratee: ResourceIteratee<MerakiClient>,

--- a/src/collector/ServicesClient.ts
+++ b/src/collector/ServicesClient.ts
@@ -118,6 +118,13 @@ export class ServicesClient {
     }
   }
 
+  /**
+   * iterateDevices iterates all devices in a network
+   * @url https://developer.cisco.com/meraki/api-v1/#!get-network-devices
+   * @paginated false
+   * @param networkId the network id
+   * @param iteratee  the iteratee callback function
+   */
   async iterateDevices(
     networkId: string,
     iteratee: ResourceIteratee<MerakiDevice>,
@@ -126,6 +133,13 @@ export class ServicesClient {
     await this.iterateAll(url, iteratee);
   }
 
+  /**
+   * iterateSamlRoles iterates all SAML roles in a network
+   * @url https://developer.cisco.com/meraki/api-v1/#!get-organization-saml-roles
+   * @paginated false
+   * @param organizationId the organization id
+   * @param iteratee  the iteratee callback function
+   */
   async iterateSamlRoles(
     organizationId: string,
     iteratee: ResourceIteratee<MerakiSamlRole>,
@@ -134,14 +148,29 @@ export class ServicesClient {
     await this.iterateAll(url, iteratee);
   }
 
+  /**
+   * iterateNetworks iterates all networks in an organization
+   * @url https://developer.cisco.com/meraki/api-v1/#!get-organization-networks
+   * @paginated true
+   * @param organizationId the organization id
+   * @param iteratee  the iteratee callback function
+   */
   async iterateNetworks(
     organizationId: string,
     iteratee: ResourceIteratee<MerakiNetwork>,
   ): Promise<void> {
-    const url = `/organizations/${organizationId}/networks`;
-    await this.iterateAll(url, iteratee);
+    const url = `${this.BASE_URL}/organizations/${organizationId}/networks`;
+
+    await this.iterateAll(url, iteratee, { perPage: 50 });
   }
 
+  /**
+   * iterateAdmins iterates all admins in a network
+   * @url https://developer.cisco.com/meraki/api-v1/#!get-organization-admins
+   * @paginated false
+   * @param organizationId the organization id
+   * @param iteratee  the iteratee callback function
+   */
   async iterateAdmins(
     organizationId: string,
     iteratee: ResourceIteratee<MerakiAdminUser>,
@@ -155,6 +184,7 @@ export class ServicesClient {
     iteratee: ResourceIteratee<MerakiClient>,
   ) {
     const url = `/networks/${networkId}/clients`;
+
     const errHandler: ErrorHandler = (err: any) => {
       if (err instanceof GaxiosError) {
         if (err.response?.status === 400 || err.response?.status === 404) {
@@ -175,9 +205,16 @@ export class ServicesClient {
       }
     };
 
-    await this.iterateAll(url, iteratee, { perPage: 100 }, errHandler);
+    await this.iterateAll(url, iteratee, { perPage: 50 }, errHandler);
   }
 
+  /**
+   * iterateSSIDs iterates all SSIDs in a network
+   * @url https://developer.cisco.com/meraki/api-v1/#!get-network-wireless-ssids
+   * @paginated false
+   * @param networkId the network id
+   * @param iteratee the iteratee callback function
+   */
   async iterateSSIDs(
     networkId: string,
     iteratee: ResourceIteratee<MerakiSSID>,
@@ -186,11 +223,19 @@ export class ServicesClient {
     await this.iterateAll(url, iteratee);
   }
 
+  /**
+   * iterateVlans iterates all vlans in a network
+   * @url https://developer.cisco.com/meraki/api-v1/#!get-network-appliance-vlans
+   * @paginated false
+   * @param networkId the network id
+   * @param iteratee  the iteratee callback function
+   */
   async iterateVlans(
     networkId: string,
     iteratee: ResourceIteratee<MerakiVlan>,
   ): Promise<void> {
     const url = `/networks/${networkId}/appliance/vlans`;
+
     const errHandler = (err: any) => {
       if (err instanceof GaxiosError) {
         if (err.response?.status === 400) {
@@ -216,6 +261,8 @@ export class ServicesClient {
 
   /**
    * Get Organizations
+   * @url https://developer.cisco.com/meraki/api-v1/#!get-organizations
+   * @paginated false
    */
   async getOrganizations(): Promise<MerakiOrganization[]> {
     try {

--- a/src/collector/ServicesClient.ts
+++ b/src/collector/ServicesClient.ts
@@ -159,7 +159,7 @@ export class ServicesClient {
     organizationId: string,
     iteratee: ResourceIteratee<MerakiNetwork>,
   ): Promise<void> {
-    const url = `${this.BASE_URL}/organizations/${organizationId}/networks`;
+    const url = `/organizations/${organizationId}/networks`;
 
     await this.iterateAll(url, iteratee, { perPage: 50 });
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@ import { RelationshipClass } from '@jupiterone/data-model';
 import {
   RelationshipDirection,
   StepEntityMetadata,
+  StepMappedRelationshipMetadata,
 } from '@jupiterone/integration-sdk-core';
 
 export const StepIds = {
@@ -129,7 +130,10 @@ export const TargetEntities = {
   },
 };
 
-export const MappedRelationships = {
+export const MappedRelationships: Record<
+  'DEVICE_CONNECTS_INTERNET' | 'NETWORK_HAS_CLIENT',
+  StepMappedRelationshipMetadata
+> = {
   DEVICE_CONNECTS_INTERNET: {
     _type: 'meraki_device_connects_internet',
     sourceType: Entities.DEVICE._type,
@@ -140,13 +144,6 @@ export const MappedRelationships = {
   NETWORK_HAS_CLIENT: {
     _type: 'meraki_network_has_client',
     sourceType: Entities.NETWORK._type,
-    _class: RelationshipClass.HAS,
-    targetType: 'host',
-    direction: RelationshipDirection.FORWARD,
-  },
-  VLAN_HAS_CLIENT: {
-    _type: 'meraki_vlan_has_client',
-    sourceType: Entities.VLAN._type,
     _class: RelationshipClass.HAS,
     targetType: 'host',
     direction: RelationshipDirection.FORWARD,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,8 @@
 import { RelationshipClass } from '@jupiterone/data-model';
-import { RelationshipDirection } from '@jupiterone/integration-sdk-core';
+import {
+  RelationshipDirection,
+  StepEntityMetadata,
+} from '@jupiterone/integration-sdk-core';
 
 export const StepIds = {
   FETCH_RESOURCES: 'fetch-resources',
@@ -13,7 +16,17 @@ export const StepIds = {
   FETCH_WIFI: 'fetch-wifi',
 };
 
-export const Entities = {
+export const Entities: Record<
+  | 'ACCOUNT'
+  | 'ORGANIZATION'
+  | 'ADMIN'
+  | 'SAML_ROLE'
+  | 'NETWORK'
+  | 'WIFI'
+  | 'VLAN'
+  | 'DEVICE',
+  StepEntityMetadata
+> = {
   ACCOUNT: {
     resourceName: 'Account',
     _type: 'cisco_meraki_account',
@@ -53,6 +66,13 @@ export const Entities = {
     resourceName: 'Device',
     _type: 'meraki_device',
     _class: ['Device', 'Host'],
+    schema: {
+      additionalProperties: true,
+      properties: {
+        name: { type: 'string' },
+      },
+      required: ['name'],
+    },
   },
 };
 
@@ -102,13 +122,8 @@ export const Relationships = {
 };
 
 export const TargetEntities = {
-  INTERNET: {
-    resourceName: 'Internet',
-    _type: 'internet',
-    _class: ['Internet', 'Network'],
-  },
   CLIENT: {
-    reourceName: 'Client',
+    resourceName: 'Client',
     _type: 'host',
     _class: ['Device', 'Host'],
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -131,7 +131,7 @@ export const TargetEntities = {
 };
 
 export const MappedRelationships: Record<
-  'DEVICE_CONNECTS_INTERNET' | 'NETWORK_HAS_CLIENT',
+  'DEVICE_CONNECTS_INTERNET' | 'NETWORK_HAS_CLIENT' | 'VLAN_HAS_CLIENT',
   StepMappedRelationshipMetadata
 > = {
   DEVICE_CONNECTS_INTERNET: {
@@ -144,6 +144,13 @@ export const MappedRelationships: Record<
   NETWORK_HAS_CLIENT: {
     _type: 'meraki_network_has_client',
     sourceType: Entities.NETWORK._type,
+    _class: RelationshipClass.HAS,
+    targetType: 'host',
+    direction: RelationshipDirection.FORWARD,
+  },
+  VLAN_HAS_CLIENT: {
+    _type: 'meraki_vlan_has_client',
+    sourceType: Entities.VLAN._type,
     _class: RelationshipClass.HAS,
     targetType: 'host',
     direction: RelationshipDirection.FORWARD,

--- a/src/converter/entities.ts
+++ b/src/converter/entities.ts
@@ -245,7 +245,7 @@ export const convertDevice = (
         category: 'network',
         make: 'Cisco Meraki',
         name: data.name ?? data.networkId,
-        displayName: data.name,
+        displayName: data.name ?? data.networkId,
         hostname: data.name,
         macAddress: data.mac,
         ipAddress: data.lanIp ? data.lanIp : undefined,

--- a/src/converter/entities.ts
+++ b/src/converter/entities.ts
@@ -244,7 +244,7 @@ export const convertDevice = (
         _class: Entities.DEVICE._class,
         category: 'network',
         make: 'Cisco Meraki',
-        name: data.name,
+        name: data.name ?? data.networkId,
         displayName: data.name,
         hostname: data.name,
         macAddress: data.mac,
@@ -269,7 +269,6 @@ export const convertDevice = (
         url: data.url,
         webLink: data.url,
 
-        // this doesn't follow the data model, notes should be string[]
         notes: data.notes,
 
         lanIp: data.lanIp,

--- a/src/converter/relationships.ts
+++ b/src/converter/relationships.ts
@@ -29,3 +29,24 @@ export const convertNetworkClientRelationship = (
     },
   });
 };
+
+export const convertVlanClientRelationship = (
+  sourceEntity: Entity,
+  client: MerakiClient,
+): Relationship => {
+  return createMappedRelationship({
+    _class: RelationshipClass.HAS,
+    _type: MappedRelationships.VLAN_HAS_CLIENT._type,
+    source: sourceEntity,
+    targetFilterKeys: [['_class', 'macAddress']],
+    target: {
+      ...convertProperties(client),
+      _class: TargetEntities.CLIENT._class,
+      displayName: client.description || client.mac,
+      macAddress: client.mac,
+      ipAddress: client.ip,
+      firstSeenOn: parseTimePropertyValue(client.firstSeen),
+      lastSeenOn: parseTimePropertyValue(client.lastSeen),
+    },
+  });
+};

--- a/src/converter/relationships.ts
+++ b/src/converter/relationships.ts
@@ -2,37 +2,30 @@ import { MerakiClient } from '../collector';
 import {
   convertProperties,
   createMappedRelationship,
+  Entity,
   parseTimePropertyValue,
   Relationship,
   RelationshipClass,
-  RelationshipDirection,
 } from '@jupiterone/integration-sdk-core';
-import createEntityKey from './utils/createEntityKey';
-import { Entities, MappedRelationships, TargetEntities } from '../constants';
+import { MappedRelationships, TargetEntities } from '../constants';
 
 export const convertNetworkClientRelationship = (
-  networkId: string,
+  sourceEntity: Entity,
   client: MerakiClient,
-): Relationship =>
-  createMappedRelationship({
+): Relationship => {
+  return createMappedRelationship({
     _class: RelationshipClass.HAS,
-    _type: client.vlan
-      ? MappedRelationships.VLAN_HAS_CLIENT._type
-      : MappedRelationships.NETWORK_HAS_CLIENT._type,
-    _mapping: {
-      relationshipDirection: RelationshipDirection.FORWARD,
-      sourceEntityKey: client.vlan
-        ? createEntityKey(Entities.VLAN._type, `${networkId}:${client.vlan}`)
-        : createEntityKey(Entities.NETWORK._type, networkId),
-      targetFilterKeys: [['_class', 'macAddress']],
-      targetEntity: {
-        ...convertProperties(client),
-        _class: TargetEntities.CLIENT._class,
-        displayName: client.description || client.mac,
-        macAddress: client.mac,
-        ipAddress: client.ip,
-        firstSeenOn: parseTimePropertyValue(client.firstSeen),
-        lastSeenOn: parseTimePropertyValue(client.lastSeen),
-      },
+    _type: MappedRelationships.NETWORK_HAS_CLIENT._type,
+    source: sourceEntity,
+    targetFilterKeys: [['_class', 'macAddress']],
+    target: {
+      ...convertProperties(client),
+      _class: TargetEntities.CLIENT._class,
+      displayName: client.description || client.mac,
+      macAddress: client.mac,
+      ipAddress: client.ip,
+      firstSeenOn: parseTimePropertyValue(client.firstSeen),
+      lastSeenOn: parseTimePropertyValue(client.lastSeen),
     },
   });
+};

--- a/src/steps/fetch-clients/index.ts
+++ b/src/steps/fetch-clients/index.ts
@@ -1,4 +1,7 @@
-import { convertNetworkClientRelationship } from '../../converter';
+import {
+  convertNetworkClientRelationship,
+  convertVlanClientRelationship,
+} from '../../converter';
 // import { IntegrationConfig } from '../../types';
 
 import {
@@ -14,6 +17,7 @@ import {
 } from '../../collector';
 import { Entities, MappedRelationships, StepIds } from '../../constants';
 import { IntegrationConfig } from '../../config';
+import createEntityKey from '../../converter/utils/createEntityKey';
 
 export const clientSteps: IntegrationStep<IntegrationConfig>[] = [
   {
@@ -21,7 +25,10 @@ export const clientSteps: IntegrationStep<IntegrationConfig>[] = [
     name: 'Fetch Meraki Network Clients',
     entities: [],
     relationships: [],
-    mappedRelationships: [MappedRelationships.NETWORK_HAS_CLIENT],
+    mappedRelationships: [
+      MappedRelationships.NETWORK_HAS_CLIENT,
+      MappedRelationships.VLAN_HAS_CLIENT,
+    ],
     dependsOn: [StepIds.FETCH_NETWORKS],
     executionHandler: fetchClients,
   },
@@ -38,9 +45,22 @@ export async function fetchClients({
     async (networkEntity) => {
       const network = getRawData(networkEntity) as MerakiNetwork;
       await client.iterateClients(network.id, async (client: MerakiClient) => {
-        await jobState.addRelationship(
-          convertNetworkClientRelationship(networkEntity, client),
+        const key = createEntityKey(
+          Entities.VLAN._type,
+          network.id + ':' + client.vlan,
         );
+        // We aren't able to fetch all vlans, so the key may not exist
+        const vlanEntity = await jobState.findEntity(key);
+        if (vlanEntity) {
+          await jobState.addRelationship(
+            convertVlanClientRelationship(vlanEntity, client),
+          );
+        } else {
+          // if we can't build the relationship from the vlan, build from the network instead
+          await jobState.addRelationship(
+            convertNetworkClientRelationship(networkEntity, client),
+          );
+        }
       });
     },
   );

--- a/src/steps/fetch-clients/index.ts
+++ b/src/steps/fetch-clients/index.ts
@@ -21,10 +21,7 @@ export const clientSteps: IntegrationStep<IntegrationConfig>[] = [
     name: 'Fetch Meraki Network Clients',
     entities: [],
     relationships: [],
-    mappedRelationships: [
-      MappedRelationships.NETWORK_HAS_CLIENT,
-      MappedRelationships.VLAN_HAS_CLIENT,
-    ],
+    mappedRelationships: [MappedRelationships.NETWORK_HAS_CLIENT],
     dependsOn: [StepIds.FETCH_NETWORKS],
     executionHandler: fetchClients,
   },
@@ -42,7 +39,7 @@ export async function fetchClients({
       const network = getRawData(networkEntity) as MerakiNetwork;
       await client.iterateClients(network.id, async (client: MerakiClient) => {
         await jobState.addRelationship(
-          convertNetworkClientRelationship(network.id, client),
+          convertNetworkClientRelationship(networkEntity, client),
         );
       });
     },

--- a/test/recording.ts
+++ b/test/recording.ts
@@ -42,7 +42,7 @@ function redact(entry): void {
   const DEFAULT_REDACT = '[REDACTED]';
   const keysToRedactMap = new Map();
 
-  keysToRedactMap.set('url', DEFAULT_REDACT);
+  keysToRedactMap.set('url', 'http://redactedurl.com');
   keysToRedactMap.set('samlConsumerUrl', DEFAULT_REDACT);
   keysToRedactMap.set('samlConsumerUrls', [DEFAULT_REDACT]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,20 +762,20 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jupiterone/data-model@^0.49.0":
-  version "0.49.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.49.0.tgz#453dc055ab2dd5fc3f913fde53579e28cecd0f24"
-  integrity sha512-BG3ld27HbZ7X5b4o6vbP0ugZawUCOSHxYhWK0H3eaQRg8zBNK4lxgeH1ZqnaRuoRqs/nxOuZlt77ozhPyCLQMQ==
+"@jupiterone/data-model@^0.51.0":
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.51.0.tgz#6defff71e6be3a08012733ed487f6232561a7750"
+  integrity sha512-NtV6pzYis0WPxLt793GPeNqLKUwBshx1LANUISd+n5q9V3EooVafThgy/0GoJ233R9GQVHQpIWRkJZuiLJUuhg==
   dependencies:
     ajv "^8.0.0"
     ajv-formats "^2.0.0"
 
-"@jupiterone/integration-sdk-cli@^8.13.11":
-  version "8.13.11"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-8.13.11.tgz#ce208e646c3a297d6f60b95fe8659f8a87a79098"
-  integrity sha512-AsnUWHiTkfqHiZsPJM7aEXW0gC2o/4xkrRSMIG7NBxckPJ/kCf8uD7AWeR8oMT880MVMU0KFJWzVSgeL0FesoQ==
+"@jupiterone/integration-sdk-cli@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-8.18.1.tgz#e67f0b52269b5b273b3ddb8fb290df973a7dccb6"
+  integrity sha512-OWWKDOe86pcWxPpNXWiepb2G4d18QXx1X/A4kMidVKuMPrPEFCYy8FZsDnsIRQOAxI/2Fwu5r3pwDLIXp1FWzw==
   dependencies:
-    "@jupiterone/integration-sdk-runtime" "^8.13.11"
+    "@jupiterone/integration-sdk-runtime" "^8.18.1"
     chalk "^4"
     commander "^5.0.0"
     fs-extra "^10.1.0"
@@ -789,22 +789,22 @@
     upath "^1.2.0"
     vis "^4.21.0-EOL"
 
-"@jupiterone/integration-sdk-core@^8.13.11":
-  version "8.13.11"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-8.13.11.tgz#6bb67df92bc943f68d48e99d67fbb74a72dddc49"
-  integrity sha512-/YzyY9TVyoD7mwEL9T4TuVHcHG2wMzun5DcF7dWJxClZDNlRPssoyoI5xIIeYdR0YYjuT8t7BbCk8SMfbfxvhg==
+"@jupiterone/integration-sdk-core@^8.17.0", "@jupiterone/integration-sdk-core@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-8.18.1.tgz#93e24a957d1ed630fdd1ddea02ac1a47102e5ae8"
+  integrity sha512-h8dlTvcskQZV/VsWQy85hG3BXnnZQslVevpnJH7pz/MyapEZvNRRcJmhn9EfOjFpMNjRfr4vlrQngRo6C+vGNA==
   dependencies:
-    "@jupiterone/data-model" "^0.49.0"
+    "@jupiterone/data-model" "^0.51.0"
     lodash "^4.17.21"
     uuid "^8.3.2"
 
-"@jupiterone/integration-sdk-dev-tools@^8.13.11":
-  version "8.13.11"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-8.13.11.tgz#1f0ca330c480e340b51148ff175b9cb6497ab498"
-  integrity sha512-VfcTGvFC12kMpCZFwEe8tazm3WYxa73gov1fkfrBhiADDIWoLYGVpuXyxF2/VYG/jXjC7wxrAblnbc4h4fJxRg==
+"@jupiterone/integration-sdk-dev-tools@^8.17.0":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-8.18.1.tgz#e396acaedc2635e9e9700179ee45acc9535352be"
+  integrity sha512-W8EQ5AVfTeLcCwr67rHxdXvMMt2qDqFreibud32XRlwSnZHyNqOJmPjNZkSL/3nuxUHAMYO5apPcVRCoy7xzEQ==
   dependencies:
-    "@jupiterone/integration-sdk-cli" "^8.13.11"
-    "@jupiterone/integration-sdk-testing" "^8.13.11"
+    "@jupiterone/integration-sdk-cli" "^8.18.1"
+    "@jupiterone/integration-sdk-testing" "^8.18.1"
     "@types/jest" "^27.1.0"
     "@types/node" "^14.0.5"
     "@typescript-eslint/eslint-plugin" "^4.22.0"
@@ -820,12 +820,12 @@
     ts-node "^9.1.1"
     typescript "^4.2.4"
 
-"@jupiterone/integration-sdk-runtime@^8.13.11":
-  version "8.13.11"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-8.13.11.tgz#b40844c84ac180be66e221adefd27bc242209160"
-  integrity sha512-UuR4IlIVGyiEyl9jG4SKdh1DPKhk3u0R9dLqo/wGXUkrQP2GaBwIWo/c72NAAbg41l3BaFNjw27w/kmM3SdwWg==
+"@jupiterone/integration-sdk-runtime@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-8.18.1.tgz#cff56b481549ae866320a4a711d08af564af170e"
+  integrity sha512-m4yVq0slyovYuBnMAo8y+Z6Obzwkxvl6oXvEsIPkcU99GaCKQDVi1Y9OhsAlWylkv6ojE48lhyroYn4PFAEF+A==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^8.13.11"
+    "@jupiterone/integration-sdk-core" "^8.18.1"
     "@lifeomic/alpha" "^1.4.0"
     "@lifeomic/attempt" "^3.0.3"
     async-sema "^3.1.0"
@@ -843,13 +843,13 @@
     rimraf "^3.0.2"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-testing@^8.13.11":
-  version "8.13.11"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-8.13.11.tgz#91456b6ec1d690d579599c4d127845ddc8930218"
-  integrity sha512-eB8AfmB7VHfDoYfh6SJAWzwMbHh/tH7yPhfhKD0l6xF+kQc/JqAr/24Mq6ELKp0BSSCAS4cJwTzK9mUoLhtZYw==
+"@jupiterone/integration-sdk-testing@^8.17.0", "@jupiterone/integration-sdk-testing@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-8.18.1.tgz#1fbd7c1ffb0b3df262e29ad82d5342ed5e48277f"
+  integrity sha512-Fl/ta/UUrf+JLXzptUEw4Dzg1vbFRFjVSjMFre0WR777d5SacX3ClJFadEfLcV/yfVTpDFt7SKqdcKim5Wakng==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^8.13.11"
-    "@jupiterone/integration-sdk-runtime" "^8.13.11"
+    "@jupiterone/integration-sdk-core" "^8.18.1"
+    "@jupiterone/integration-sdk-runtime" "^8.18.1"
     "@pollyjs/adapter-node-http" "^6.0.5"
     "@pollyjs/core" "^6.0.5"
     "@pollyjs/persister-fs" "^6.0.5"
@@ -3918,6 +3918,13 @@ parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-link-header@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-link-header/-/parse-link-header-2.0.0.tgz#949353e284f8aa01f2ac857a98f692b57733f6b7"
+  integrity sha512-xjU87V0VyHZybn2RrCX5TIFGxTVZE6zqqZWMPlIKiSKuWh/X5WZdt+w1Ki1nXB+8L/KtL+nZ4iq+sfI6MrhhMw==
+  dependencies:
+    xtend "~4.0.1"
+
 parse5@6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
@@ -4946,6 +4953,11 @@ xtend@~2.1.1:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
   dependencies:
     object-keys "~0.4.0"
+
+xtend@~4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1081,6 +1081,11 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
 
+"@types/parse-link-header@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse-link-header/-/parse-link-header-2.0.0.tgz#a94d86ac2d13e3cdef4429c977217084e32378e7"
+  integrity sha512-KbqcQLdRaawDOfXnwqr6nvhe1MV+Uv/Ww+ViSx7Ujgw9X5qCgObLP52B1ZSJqZD8FK1y/4o+bJQTUrZOynegcg==
+
 "@types/prettier@^2.1.5":
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.3.tgz#68ada76827b0010d0db071f739314fa429943d0a"


### PR DESCRIPTION
# Description

This PR adds pagination to two endpoints - the  `/organizations/${organizationId}/networks` endpoint and the `/networks/${networkId}/clients` endpoint. The default page size for these endpoints is 10, but I've opted to go for 50. The maximum is 1000.

~~This PR also drops support for the `MappedRelationships.VLAN_HAS_CLIENT` relationship. While this is a breaking change, the impact is limited as 1. The clients endpoint wasn't being paginated before so relationships weren't being made. 2. The relationship was almost always mapping _from_ an entity that didn't exist.~~

Update: keeping the relationship